### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   Build-and-Push:


### PR DESCRIPTION
Potential fix for [https://github.com/community-ban-list/Communitybanlist/security/code-scanning/3](https://github.com/community-ban-list/Communitybanlist/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root (applies to all jobs) with the minimal required scope. For this workflow, `contents: read` is the safest and most compatible baseline and satisfies CodeQL’s requirement without changing behavior.

**Where to change:** `.github/workflows/docker-image.yml`, near the top-level keys (after `on:` block is a clear location), before `jobs:`.

**What to add:**
```yml
permissions:
  contents: read
```

No imports, methods, or dependencies are needed (YAML workflow change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
